### PR TITLE
Pause Automerge PR

### DIFF
--- a/.github/workflows/action-wip-blocker.yml
+++ b/.github/workflows/action-wip-blocker.yml
@@ -1,0 +1,15 @@
+name: Automerge Blocker
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, edited, opened, synchronize, reopened]
+
+jobs:
+  check_wip:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Block if WIP PR
+      uses: ParanoidBeing/action-wip-blocker@v0.1.1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BLOCK_LIST: "WIP|do not merge|backend not live|Block|block"


### PR DESCRIPTION
add a GH workflow to block PR's with a `Block` label or `WIP` in PR title or comment.

Docs: https://github.com/ParanoidBeing/action-wip-blocker